### PR TITLE
feat: Integrate LangGraph backend for summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,98 @@
-# Run and deploy your AI Studio app
+# Oncall Retrospective Summarizer
 
-This contains everything you need to run your app locally.
+This application provides a UI to input daily oncall summaries and view an AI-generated retrospective summary. It uses a React frontend and a Python (Flask) backend with LangGraph to manage the summarization workflow.
 
-## Run Locally
+## Project Structure
 
-**Prerequisites:**  Node.js
+- `/`: Contains the frontend React application.
+- `/backend`: Contains the Python Flask backend application.
 
+## Setup and Running
 
-1. Install dependencies:
-   `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+You need to run two components: the Frontend UI and the Backend Server.
+
+### 1. Backend Server (Python Flask with LangGraph)
+
+The backend server handles the logic of collecting daily summaries and generating retrospective summaries using LangGraph and the Gemini API.
+
+**Prerequisites:**
+- Python 3.8+
+- pip
+
+**Setup:**
+
+1.  **Navigate to the backend directory:**
+    ```bash
+    cd backend
+    ```
+
+2.  **Create a Python virtual environment (recommended):**
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    ```
+
+3.  **Install Python dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+4.  **Set up environment variables:**
+    Create a file named `.env` in the `backend` directory (`backend/.env`) and add your Gemini API key:
+    ```env
+    GEMINI_API_KEY="YOUR_GEMINI_API_KEY_HERE"
+    # Optional: You can also set Flask environment variables if needed
+    # FLASK_APP=app.py
+    # FLASK_DEBUG=1
+    ```
+    Replace `"YOUR_GEMINI_API_KEY_HERE"` with your actual Gemini API key.
+
+**Running the Backend:**
+
+1.  Ensure your virtual environment is activated and you are in the `backend` directory.
+2.  Run the Flask application:
+    ```bash
+    python app.py
+    ```
+    The backend server will start, typically on `http://localhost:5000`. You should see output indicating the server is running.
+
+### 2. Frontend UI (React)
+
+The frontend provides the user interface for submitting daily notes and viewing summaries.
+
+**Prerequisites:**
+- Node.js (LTS version recommended)
+- npm (usually comes with Node.js)
+
+**Setup:**
+
+1.  **Navigate to the root project directory (if you were in `backend`, go up one level `cd ..`):**
+    Ensure you are in the main project directory that contains `package.json`.
+
+2.  **Install Node.js dependencies:**
+    ```bash
+    npm install
+    ```
+
+3.  **Environment Variables for Frontend (Optional):**
+    The frontend primarily communicates with the local backend. The direct `GEMINI_API_KEY` previously set in `frontend/.env.local` or similar for direct Gemini calls from the client is no longer the primary method for the features modified in this project (daily summary submission and retrospective generation), as the backend now handles Gemini interactions for these. However, other parts of the frontend might still use it if they make direct calls. For this project's core functionality, the backend's `.env` is critical.
+
+**Running the Frontend:**
+
+1.  Ensure you are in the root project directory.
+2.  Run the React application:
+    ```bash
+    npm run dev
+    ```
+    The frontend development server will start, typically on `http://localhost:5173` (Vite's default) or another port if specified. Your browser should open automatically, or you can navigate to the provided URL.
+
+## How it Works
+
+1.  The user interacts with the **Frontend UI**.
+2.  To submit a "daily summary" (currently actioned via the "Create Your Own Insight" feature by selecting tags), the frontend sends the data to the **Backend Server's** `/api/submit_daily` endpoint.
+3.  The Backend Server uses LangGraph to add this daily summary to a persistent (in-memory for now) list of summaries for the current session/thread.
+4.  When the frontend loads or after a new daily summary is submitted, it calls the Backend Server's `/api/retrospective` endpoint.
+5.  The Backend Server then instructs LangGraph to take all accumulated daily summaries for the session/thread, generate a consolidated text, and use the Gemini API to produce a retrospective summary.
+6.  This summary is returned to the frontend and displayed.
+
+**Note:** The current backend implementation uses an in-memory store (`MemorySaver` for LangGraph) for daily summaries. This means summaries will be lost if the backend server restarts. For persistent storage, the checkpointer in `backend/app.py` would need to be changed to something like `RedisSaver` or a database-backed solution. All users also currently share the same data thread.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,125 @@
+import os
+from flask import Flask, jsonify, request
+from dotenv import load_dotenv
+from langgraph.checkpoint.memory import MemorySaver
+
+# Load environment variables
+load_dotenv()
+
+# Import graph definition (assuming graph.py is in the same directory or accessible)
+from graph import workflow, GraphState # Make sure graph.py is importable
+
+app = Flask(__name__)
+
+# Configure Gemini API Key (ensure it's set in .env or environment)
+gemini_api_key = os.getenv("GEMINI_API_KEY")
+if not gemini_api_key:
+    raise ValueError("GEMINI_API_KEY not found in environment variables.")
+
+# Compile the graph with a checkpointer
+# MemorySaver is used here for simplicity. For production, use a persistent checkpointer.
+memory_saver = MemorySaver()
+app_graph = workflow.compile(checkpointer=memory_saver)
+
+# Helper to get a unique config for each request or session
+# For now, we'll use a static thread_id for simplicity in demonstration.
+# In a real app, this should be dynamic (e.g., user ID, session ID).
+DEFAULT_THREAD_ID = "global_retro_thread"
+
+def get_thread_config(thread_id: str = DEFAULT_THREAD_ID):
+    return {"configurable": {"thread_id": thread_id}}
+
+@app.route('/health', methods=['GET'])
+def health_check():
+    return jsonify({"status": "healthy"}), 200
+
+@app.route('/api/submit_daily', methods=['POST'])
+def submit_daily_summary():
+    data = request.json
+    if not data or "text" not in data:
+        return jsonify({"error": "Missing 'text' in request body"}), 400
+
+    daily_entry = {"text": data["text"]} #
+    # Potentially add other fields like date, author, etc. from data if needed by graph state
+
+    config = get_thread_config() # Using default thread for now
+
+    try:
+        # The input to invoke for "add_summary_entry" node should match its expected input key.
+        # In graph.py, the lambda is `lambda state, new_summary_input: ...`
+        # So, the key in the invoke payload should be "new_summary_input".
+        app_graph.invoke({"new_summary_input": daily_entry}, config)
+        current_state = app_graph.get_state(config)
+        return jsonify({
+            "message": "Daily summary submitted successfully.",
+            "current_summary_count": len(current_state.values.get("daily_summaries", [])) if current_state else 0
+        }), 200
+    except Exception as e:
+        return jsonify({"error": f"Failed to process daily summary: {str(e)}"}), 500
+
+@app.route('/api/retrospective', methods=['GET']) # Changed to GET for simplicity, could be POST if params are complex
+def get_retrospective():
+    config = get_thread_config() # Using default thread
+
+    try:
+        # Ensure the graph state exists for the thread
+        current_state = app_graph.get_state(config)
+        if not current_state or not current_state.values.get("daily_summaries"):
+            return jsonify({"summary": "No daily summaries available to generate a retrospective.", "details": []}), 200
+
+        # Invoke the 'generate_retrospective_summary' node.
+        # This node reads from the current state.
+        # Note: The 'invoke' method on a compiled graph usually starts from the graph's entry point.
+        # If 'generate_retrospective_summary' is not an entry point or reachable from one based on current state,
+        # this might not work as expected without further graph structure (e.g. conditional edges).
+        # A more direct way if the graph isn't set up with complex routing for this:
+        # result_state = summarize_daily_entries_node(current_state.values) # Calling the node function directly
+
+        # However, to use the compiled graph properly with state:
+        # We need to ensure the graph can transition to 'generate_retrospective_summary'.
+        # For simplicity, if our graph is just a collection of nodes and Flask decides which to call,
+        # we might need a way to update the state after calling a specific node function.
+        # The current graph definition in graph.py does not link 'add_summary_entry' to 'generate_retrospective_summary'.
+        # They are treated as separate callable units.
+
+        # Let's try to invoke the specific node via the graph, assuming it can be targeted.
+        # LangGraph's `invoke` typically requires sending inputs that might trigger transitions.
+        # If 'generate_retrospective_summary' is a standalone node we want to run on current state:
+
+        # Option 1: Update graph to have an edge or entry point for summarization.
+        # (This would be a change in graph.py)
+
+        # Option 2: Call the node function directly with the current state if the graph object allows it.
+        # (Not standard for `app_graph.invoke` which usually takes inputs for the *start* of the graph or a runnable.)
+
+        # Option 3: Use `app_graph.update_state` and then `app_graph.invoke` if the node is reachable.
+        # Or, more simply, if the node just needs the state, we can call the underlying node function.
+
+        # Let's assume `summarize_daily_entries_node` (the function itself) can be called with the current state values.
+        # This bypasses invoking it *through* the graph's compiled execution path for this specific call,
+        # but uses the state managed by the graph's checkpointer.
+        from graph import summarize_daily_entries_node # Import the function directly for this
+
+        summary_output = summarize_daily_entries_node(current_state.values)
+
+        # Update the state with the new summary (if the node doesn't do it implicitly via graph execution)
+        # The node itself returns the new state components.
+        if summary_output.get("error"):
+             return jsonify({"error": summary_output["error"]}), 500
+
+        # To persist this change back into the graph's state:
+        app_graph.update_state(config, {"retrospective_summary": summary_output.get("retrospective_summary")})
+
+        return jsonify({
+            "summary": summary_output.get("retrospective_summary"),
+            "source_summary_count": len(current_state.values.get("daily_summaries", []))
+        }), 200
+
+    except Exception as e:
+        print(f"Error in /api/retrospective: {e}")
+        return jsonify({"error": f"Failed to generate retrospective: {str(e)}"}), 500
+
+if __name__ == '__main__':
+    # Make sure to set FLASK_APP=app.py (or your filename) in your environment
+    # And FLASK_DEBUG=1 for development mode
+    app.run(debug=True, port=5000) # Default Flask port is 5000

--- a/backend/graph.py
+++ b/backend/graph.py
@@ -1,0 +1,123 @@
+import os
+from typing import TypedDict, Annotated, Sequence
+from langgraph.graph import StateGraph, END
+from langchain_google_genai import ChatGoogleGenerativeAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Initialize LLM
+llm = ChatGoogleGenerativeAI(model="gemini-pro", google_api_key=os.getenv("GEMINI_API_KEY"))
+
+class GraphState(TypedDict):
+    daily_summaries: list[dict]
+    retrospective_summary: str
+    error: str | None
+
+# Node functions
+def add_daily_summary_node(state: GraphState, new_summary: dict):
+    """Adds a new daily summary to the list."""
+    summaries = state.get("daily_summaries", [])
+    summaries.append(new_summary)
+    return {"daily_summaries": summaries, "error": None}
+
+def summarize_daily_entries_node(state: GraphState):
+    """Summarizes all daily entries to generate a retrospective."""
+    summaries = state.get("daily_summaries", [])
+    if not summaries:
+        return {"retrospective_summary": "No daily summaries to process.", "error": None}
+
+    try:
+        texts_to_summarize = "\n\n---\n\n".join([s.get("text", "") for s in summaries if s.get("text")])
+        if not texts_to_summarize.strip():
+            return {"retrospective_summary": "No text found in daily summaries to process.", "error": None}
+
+        prompt = f"Please provide a concise retrospective summary of the following daily entries:\n\n{texts_to_summarize}"
+        response = llm.invoke(prompt)
+        return {"retrospective_summary": response.content, "error": None}
+    except Exception as e:
+        print(f"Error during summarization: {e}")
+        return {"retrospective_summary": "", "error": f"Failed to generate summary: {str(e)}"}
+
+# Node function for adding summary - modified to take direct input for clarity in graph.
+def add_summary_node_direct_input(state: GraphState, new_summary: dict):
+    """Adds a new daily summary to the list. Input is passed directly."""
+    summaries = state.get("daily_summaries", [])
+    summaries.append(new_summary)
+    return {"daily_summaries": summaries, "error": None}
+
+
+# Define the graph
+workflow = StateGraph(GraphState)
+
+# Nodes
+workflow.add_node("add_summary_entry", lambda state, new_summary_input: add_summary_node_direct_input(state, new_summary_input))
+workflow.add_node("generate_retrospective_summary", summarize_daily_entries_node)
+
+# Edges
+# The graph will have two main entry points that the Flask app will use:
+# 1. To add a daily summary: Call 'add_summary_entry' node.
+# 2. To generate a retrospective: Call 'generate_retrospective_summary' node.
+# These calls will be made with appropriate state management (e.g., using thread_id for persistence).
+
+# Setting a start and end isn't strictly necessary if Flask calls specific nodes.
+# However, for a graph that can run sequentially:
+# workflow.set_entry_point("add_summary_entry") # This would need an input schema
+# workflow.add_edge("add_summary_entry", END) # Or to another processing step
+
+# For our use case, the Flask app will manage the sequence:
+# - Call 'add_summary_entry' with input.
+# - Separately, call 'generate_retrospective_summary'.
+
+# Compile the graph (can be done once in app.py)
+# app_graph = workflow.compile()
+
+# Example of how one might invoke these if compiled:
+# This assumes `app_graph` is compiled and we have a way to pass `new_summary_input`
+# to the `add_summary_entry` node, perhaps by structuring the input to `invoke`.
+
+# if __name__ == '__main__':
+#     # In-memory checkpointer for local testing of stateful graph
+#     from langgraph.checkpoint.memory import MemorySaver
+#     memory_saver = MemorySaver()
+#     app_graph = workflow.compile(checkpointer=memory_saver)
+
+#     thread_id = "test_thread_1"
+#     config = {"configurable": {"thread_id": thread_id}}
+
+#     # Add first summary
+#     print(f"Current state for {thread_id}: {app_graph.get_state(config)}")
+#     app_graph.invoke({"new_summary_input": {"text": "Day 1: Project planning complete."}}, config)
+#     print(f"State after first summary for {thread_id}: {app_graph.get_state(config)}")
+
+#     # Add second summary
+#     app_graph.invoke({"new_summary_input": {"text": "Day 2: Initial coding started."}}, config)
+#     print(f"State after second summary for {thread_id}: {app_graph.get_state(config)}")
+
+#     # Add third summary to a different thread
+#     thread_id_2 = "test_thread_2"
+#     config_2 = {"configurable": {"thread_id": thread_id_2}}
+#     app_graph.invoke({"new_summary_input": {"text": "Day 1 (Thread 2): Requirements gathering."}}, config_2)
+#     print(f"State after first summary for {thread_id_2}: {app_graph.get_state(config_2)}")
+
+
+#     # Generate retrospective for the first thread
+#     # To do this, we'd invoke the 'generate_retrospective_summary' node.
+#     # The `invoke` method on a compiled graph typically starts from the entry point.
+#     # To call a specific node like 'generate_retrospective_summary', we might need to structure
+#     # the graph with conditional edges or use a different invocation method if available,
+#     # or the Flask app will call `graph.nodes['generate_retrospective_summary'].invoke(current_state)`.
+
+#     # For now, let's assume the Flask app will handle getting the state and calling the node.
+#     current_state_thread_1 = app_graph.get_state(config)
+#     if current_state_thread_1:
+#         # We need to ensure 'new_summary_input' is not required by 'summarize_daily_entries_node' if called directly
+#         # The current 'summarize_daily_entries_node' only uses 'daily_summaries' from state.
+#         retrospective_output = summarize_daily_entries_node(current_state_thread_1.values)
+#         print(f"Retrospective for {thread_id}: {retrospective_output}")
+#     else:
+#         print(f"No state found for {thread_id}")
+
+# This illustrates the stateful nature with a checkpointer.
+# The Flask app will need to implement similar logic for managing state per user/session.
+print("Graph definition loaded. Ready for compilation and integration with Flask.")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+langgraph
+langchain-google-genai
+python-dotenv

--- a/services/backendService.ts
+++ b/services/backendService.ts
@@ -1,0 +1,68 @@
+// Service to interact with the Flask backend
+
+const BASE_URL = 'http://localhost:5000/api'; // Assuming Flask runs on port 5000
+
+export interface DailySummaryPayload {
+  text: string;
+  // Add any other fields that your daily summary might contain
+  // e.g., author?: string; date?: string;
+}
+
+export interface RetrospectiveResponse {
+  summary: string;
+  source_summary_count: number;
+  error?: string;
+}
+
+export interface SubmitDailyResponse {
+  message: string;
+  current_summary_count: number;
+  error?: string;
+}
+
+/**
+ * Submits a daily summary to the backend.
+ * @param summaryPayload - The content of the daily summary.
+ * @returns The response from the backend.
+ */
+export const submitDailySummary = async (summaryPayload: DailySummaryPayload): Promise<SubmitDailyResponse> => {
+  try {
+    const response = await fetch(`${BASE_URL}/submit_daily`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(summaryPayload),
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: 'Network response was not ok' }));
+      throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error), {
+    console.error('Failed to submit daily summary:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    return { message: '', current_summary_count: 0, error: errorMessage };
+  }
+};
+
+/**
+ * Fetches the retrospective summary from the backend.
+ * @returns The retrospective summary and related data.
+ */
+export const getRetrospectiveSummary = async (): Promise<RetrospectiveResponse> => {
+  try {
+    const response = await fetch(`${BASE_URL}/retrospective`, {
+      method: 'GET', // As defined in Flask app
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: 'Network response was not ok' }));
+      throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Failed to fetch retrospective summary:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    return { summary: '', source_summary_count: 0, error: errorMessage };
+  }
+};


### PR DESCRIPTION
Adds a Python Flask backend using LangGraph to manage daily summaries and generate retrospective reports.

Key changes:
- New `backend/` directory with Flask app, LangGraph workflow, and dependencies.
- Backend exposes `/api/submit_daily` and `/api/retrospective` endpoints.
- Frontend `App.tsx` modified to call these backend endpoints instead of directly using `geminiService.ts` for these functions.
- `services/backendService.ts` created for frontend-backend communication.
- `README.md` updated with setup and run instructions for both frontend and backend, and explanation of the new architecture.
- LangGraph uses `MemorySaver` for in-memory state management per thread. Currently uses a default global thread ID.