### PR TITLE
Fix: Configure CORS for Flask backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 import os
 from flask import Flask, jsonify, request
+from flask_cors import CORS # Import CORS
 from dotenv import load_dotenv
 from langgraph.checkpoint.memory import MemorySaver
 
@@ -10,6 +11,7 @@ load_dotenv()
 from graph import workflow, GraphState # Make sure graph.py is importable
 
 app = Flask(__name__)
+CORS(app, origins=["http://localhost:5173"]) # Enable CORS for a specific origin
 
 # Configure Gemini API Key (ensure it's set in .env or environment)
 gemini_api_key = os.getenv("GEMINI_API_KEY")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 Flask
+Flask-CORS
 langgraph
 langchain-google-genai
 python-dotenv


### PR DESCRIPTION
Adds Flask-CORS to allow requests from the frontend origin (http://localhost:5173).

This change aims to resolve the CORS policy error when the frontend attempts to access backend APIs.

Changes:
- Added Flask-CORS to backend/requirements.txt.
- Imported and initialized CORS in backend/app.py, restricting allowed origins to http://localhost:5173.